### PR TITLE
Feature/server listing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -91,3 +91,20 @@
     align-items: baseline;
     justify-content: center;
 }
+
+.server_provider{
+    border-left: 10px solid #04d1c2;
+    height: 6vh;
+    margin-right: 10px;
+}
+
+.server_consumer{
+    border-left: 10px solid #808080;
+    height: 6vh;
+    margin-right: 10px;
+}
+
+.server_role_container{
+    display: flex;
+    align-items: center;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import Resource from './views/Resource';
 import Logout from './views/Logout';
 import Home from './views/Home';
 import Landing from './views/Landing';
+import Server from './views/Server';
 import './App.css';
 import Footer from './components/Footer';
 import { EnvironmentProvider } from './contexts/EnvironmentContext';
@@ -22,11 +23,12 @@ class App extends Component {
             <div className="app_wrap">
               <Router>
                 <Home path="/home" />
-                <EditUser path='/user/edit' />
-                <User path="/user" />
-                <EditGroup path='group/edit' />
-                <Group path='/group' />
-                <Resource path='/resource' />
+                <EditUser path='/users/edit' />
+                <User path="/users" />
+                <EditGroup path='groups/edit' />
+                <Group path='/groups' />
+                <Resource path='/resources' />
+                <Server path='/servers' />
                 <Landing path="/" />
                 <Logout default />
               </Router>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -29,39 +29,39 @@ function Sidebar(props) {
     const { userContext, groupContext, rescContext, zoneContext } = useServer();
 
     return (
-            <Drawer
-                className={classes.drawer}
-                variant="permanent"
-                classes={{
-                    paper: classes.drawerPaper,
-                }}
-                anchor="left"
-            >
-                <Divider />
-                <List>
-                    <MenuItem button selected={selected === 0} component={Link} to="/home" key='home'>
-                        <ListItemText primary='Home' />
-                    </MenuItem>
-                    <MenuItem button selected={selected === 1} component={Link} to="/users" key='user'>
-                        <ListItemText>Users ({userContext === undefined ? 0 : userContext.total})</ListItemText>
-                    </MenuItem>
-                    <MenuItem button selected={selected === 2} component={Link} to="/groups" key='group'>
-                        <ListItemText>Groups ({groupContext === undefined ? 0 : groupContext.total})</ListItemText>
-                    </MenuItem>
-                    <MenuItem button selected={selected === 3} component={Link} to="/resources" key='resource'>
-                        <ListItemText>Resources ({rescContext === undefined ? 0 : rescContext.total})</ListItemText>
-                    </MenuItem>
-                    <MenuItem button selected={selected === 4} component={Link} to="/servers" key='server'>
-                        <ListItemText>Servers ({zoneContext === undefined ? 0 : zoneContext.length})</ListItemText>
-                    </MenuItem>
-                </List>
-                <Divider />
-                <List>
-                    <MenuItem button component={Link} to="/logout" key='logout'>
-                        <ListItemText primary='Logout' />
-                    </MenuItem>
-                </List>
-            </Drawer>
+        <Drawer
+            className={classes.drawer}
+            variant="permanent"
+            classes={{
+                paper: classes.drawerPaper,
+            }}
+            anchor="left"
+        >
+            <Divider />
+            <List>
+                <MenuItem button selected={selected === 0} component={Link} to="/home" key='home'>
+                    <ListItemText primary='Home' />
+                </MenuItem>
+                <MenuItem button selected={selected === 1} component={Link} to="/users" key='user'>
+                    <ListItemText>Users ({userContext === undefined ? 0 : userContext.total})</ListItemText>
+                </MenuItem>
+                <MenuItem button selected={selected === 2} component={Link} to="/groups" key='group'>
+                    <ListItemText>Groups ({groupContext === undefined ? 0 : groupContext.total})</ListItemText>
+                </MenuItem>
+                <MenuItem button selected={selected === 3} component={Link} to="/resources" key='resource'>
+                    <ListItemText>Resources ({rescContext === undefined ? 0 : rescContext.total})</ListItemText>
+                </MenuItem>
+                <MenuItem button selected={selected === 4} component={Link} to="/servers" key='server'>
+                    <ListItemText>Servers ({zoneContext === undefined ? 0 : zoneContext['servers'].length + 1})</ListItemText>
+                </MenuItem>
+            </List>
+            <Divider />
+            <List>
+                <MenuItem button component={Link} to="/logout" key='logout'>
+                    <ListItemText primary='Logout' />
+                </MenuItem>
+            </List>
+        </Drawer>
     );
 }
 

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -51,6 +51,9 @@ function Sidebar(props) {
                     <MenuItem button selected={selected === 3} component={Link} to="/resources" key='resource'>
                         <ListItemText>Resources ({rescContext === undefined ? 0 : rescContext.total})</ListItemText>
                     </MenuItem>
+                    <MenuItem button selected={selected === 4} component={Link} to="/servers" key='server'>
+                        <ListItemText>Servers ({zoneContext === undefined ? 0 : zoneContext.length})</ListItemText>
+                    </MenuItem>
                 </List>
                 <Divider />
                 <List>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -39,20 +39,21 @@ function Sidebar(props) {
         >
             <Divider />
             <List>
-                <MenuItem button selected={selected === 0} component={Link} to="/home" key='home'>
+                <MenuItem button selected={selected === '1'} component={Link} to="/home" key='home'>
                     <ListItemText primary='Home' />
                 </MenuItem>
-                <MenuItem button selected={selected === 1} component={Link} to="/users" key='user'>
-                    <ListItemText>Users ({userContext === undefined ? 0 : userContext.total})</ListItemText>
+                <MenuItem button selected={selected === '2'} component={Link} to="/servers" key='server'>
+                    <ListItemText>Servers ({zoneContext === undefined ? 0 : zoneContext.length})</ListItemText>
                 </MenuItem>
-                <MenuItem button selected={selected === 2} component={Link} to="/groups" key='group'>
-                    <ListItemText>Groups ({groupContext === undefined ? 0 : groupContext.total})</ListItemText>
-                </MenuItem>
-                <MenuItem button selected={selected === 3} component={Link} to="/resources" key='resource'>
+                <MenuItem button selected={selected === '3'} component={Link} to="/resources" key='resource'>
                     <ListItemText>Resources ({rescContext === undefined ? 0 : rescContext.total})</ListItemText>
                 </MenuItem>
-                <MenuItem button selected={selected === 4} component={Link} to="/servers" key='server'>
-                    <ListItemText>Servers ({zoneContext === undefined ? 0 : zoneContext.length})</ListItemText>
+
+                <MenuItem button selected={selected === '4'} component={Link} to="/users" key='user'>
+                    <ListItemText>Users ({userContext === undefined ? 0 : userContext.total})</ListItemText>
+                </MenuItem>
+                <MenuItem button selected={selected === '5'} component={Link} to="/groups" key='group'>
+                    <ListItemText>Groups ({groupContext === undefined ? 0 : groupContext.total})</ListItemText>
                 </MenuItem>
             </List>
             <Divider />

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -52,7 +52,7 @@ function Sidebar(props) {
                     <ListItemText>Resources ({rescContext === undefined ? 0 : rescContext.total})</ListItemText>
                 </MenuItem>
                 <MenuItem button selected={selected === 4} component={Link} to="/servers" key='server'>
-                    <ListItemText>Servers ({zoneContext === undefined ? 0 : zoneContext['servers'].length + 1})</ListItemText>
+                    <ListItemText>Servers ({zoneContext === undefined ? 0 : zoneContext.length})</ListItemText>
                 </MenuItem>
             </List>
             <Divider />

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme) => ({
 function Sidebar(props) {
     const classes = useStyles();
     const selected = props.menu_id;
-    const { userContext, groupContext, rescContext} = useServer();
+    const { userContext, groupContext, rescContext, zoneContext } = useServer();
 
     return (
             <Drawer
@@ -42,17 +42,14 @@ function Sidebar(props) {
                     <MenuItem button selected={selected === 0} component={Link} to="/home" key='home'>
                         <ListItemText primary='Home' />
                     </MenuItem>
-                    <MenuItem button selected={selected === 1} component={Link} to="/user" key='user'>
+                    <MenuItem button selected={selected === 1} component={Link} to="/users" key='user'>
                         <ListItemText>Users ({userContext === undefined ? 0 : userContext.total})</ListItemText>
                     </MenuItem>
-                    <MenuItem button selected={selected === 2} component={Link} to="/group" key='group'>
+                    <MenuItem button selected={selected === 2} component={Link} to="/groups" key='group'>
                         <ListItemText>Groups ({groupContext === undefined ? 0 : groupContext.total})</ListItemText>
                     </MenuItem>
-                    <MenuItem button selected={selected === 3} component={Link} to="/resource" key='resource'>
+                    <MenuItem button selected={selected === 3} component={Link} to="/resources" key='resource'>
                         <ListItemText>Resources ({rescContext === undefined ? 0 : rescContext.total})</ListItemText>
-                    </MenuItem>
-                    <MenuItem button>
-                        <ListItemText>Servers</ListItemText>
                     </MenuItem>
                 </List>
                 <Divider />

--- a/src/contexts/ServerContext.js
+++ b/src/contexts/ServerContext.js
@@ -154,9 +154,25 @@ export const ServerProvider = ({ children }) => {
         });
     }
 
-    const loadCurrServer = (offset, perPage) => {
+    const loadCurrServer = (offset, perPage, order, orderBy) => {
         if (zoneContext !== undefined) {
-            setFilteredServers(zoneContext.slice(offset, offset + perPage));
+            let tem_servers = zoneContext;
+            let orderSyntax = order === 'asc' ? 1 : -1;
+
+            const server_sort_comparator = (a, b) => {
+                switch (orderBy) {
+                    case 'hostname':
+                        const a_fullIP = a['host_system_information']['hostname'].slice(3, a.length).split('-').map((num) => (`000${num}`).slice(-3)).join("");
+                        const b_fullIP = b['host_system_information']['hostname'].slice(3, b.length).split('-').map((num) => (`000${num}`).slice(-3)).join("");
+                        return orderSyntax * (a_fullIP - b_fullIP);
+                    case 'role':
+                        return orderSyntax * (a['server_config']['catalog_service_role'].localeCompare(b['server_config']['catalog_service_role']))
+                    case 'os':
+                        return orderSyntax * ((a['host_system_information']['os_distribution_name'] + a['host_system_information']['os_distribution_version']).localeCompare((b['host_system_information']['os_distribution_name'] + b['host_system_information']['os_distribution_version'])))
+                }
+            }
+            tem_servers.sort(server_sort_comparator);
+            setFilteredServers(tem_servers.slice(offset, offset + perPage));
         }
     }
 

--- a/src/contexts/ServerContext.js
+++ b/src/contexts/ServerContext.js
@@ -186,14 +186,8 @@ export const ServerProvider = ({ children }) => {
 
             const server_sort_comparator = (a, b) => {
                 switch (orderBy) {
-                    // NOTE: this comparator will ignore 'ip' and all '-' in ip address and concate the number together,
-                    // and edges cases are also handled here.
-                    // e.g. 'ip-172-31-13-194' will be converted to '172031013194'
-                    // 'ip-2-21-13-194' will interpreted as '0020210130194'
                     case 'hostname':
-                        const a_fullIP = a['host_system_information']['hostname'].slice(3, a.length).split('-').map((num) => (`000${num}`).slice(-3)).join("");
-                        const b_fullIP = b['host_system_information']['hostname'].slice(3, b.length).split('-').map((num) => (`000${num}`).slice(-3)).join("");
-                        return orderSyntax * (a_fullIP - b_fullIP);
+                        return orderSyntax * (a['host_system_information']['hostname']).localeCompare(b['host_system_information']['hostname']);
                     case 'role':
                         return orderSyntax * (a['server_config']['catalog_service_role'].localeCompare(b['server_config']['catalog_service_role']))
                     case 'os':

--- a/src/contexts/ServerContext.js
+++ b/src/contexts/ServerContext.js
@@ -127,7 +127,7 @@ export const ServerProvider = ({ children }) => {
                 'Authorization': localStorage.getItem('zmt-token')
             }
         }).then((res) => {
-            setZoneContext(res.data.zones);
+            setZoneContext(res.data.zones[0]);
         }).catch((e) => {
         });
 

--- a/src/views/EditGroup.js
+++ b/src/views/EditGroup.js
@@ -175,7 +175,7 @@ function EditGroup(props) {
             <main className={classes.content}>
                 <div className={classes.toolbar} />
                 <div className={classes.main}>
-                    <Link to="/group" className={classes.link_button}><Button><ArrowBackIcon /></Button></Link>
+                    <Link to="/groups" className={classes.link_button}><Button><ArrowBackIcon /></Button></Link>
                     {currentGroup[0]}
                     <br />
                     <div className="edit_filter_bar">

--- a/src/views/EditGroup.js
+++ b/src/views/EditGroup.js
@@ -171,7 +171,7 @@ function EditGroup(props) {
     return (
         <div className={classes.root}>
             <Appbar />
-            <Sidebar menu_id="2" />
+            <Sidebar menu_id="5" />
             <main className={classes.content}>
                 <div className={classes.toolbar} />
                 <div className={classes.main}>

--- a/src/views/EditUser.js
+++ b/src/views/EditUser.js
@@ -162,7 +162,7 @@ function EditUser(props) {
     return (
         <div className={classes.root}>
             <Appbar />
-            <Sidebar menu_id="1" />
+            <Sidebar menu_id="4" />
             <main className={classes.content}>
                 <div className={classes.toolbar} />
                 <div className={classes.main}>

--- a/src/views/EditUser.js
+++ b/src/views/EditUser.js
@@ -166,7 +166,7 @@ function EditUser(props) {
             <main className={classes.content}>
                 <div className={classes.toolbar} />
                 <div className={classes.main}>
-                    <Link to="/user" className={classes.link_button}><Button><ArrowBackIcon /></Button></Link>
+                    <Link to="/users" className={classes.link_button}><Button><ArrowBackIcon /></Button></Link>
                     {currentUser[0]}
                     <div className="edit_filter_bar">
                         <Typography>Find Group</Typography>

--- a/src/views/Group.js
+++ b/src/views/Group.js
@@ -113,7 +113,6 @@ function Group() {
     // pass in perPage, currentPage, filtername('' by default), order, orderBy
 
     useEffect(() => {
-        console.log(filterGroupName)
         loadGroup(perPage * (currPage - 1), perPage, filterGroupName, order, "USER_NAME");
     }, [currPage, perPage, filterGroupName, order, orderBy])
 

--- a/src/views/Group.js
+++ b/src/views/Group.js
@@ -205,7 +205,7 @@ function Group() {
     return (
         <div className={classes.root}>
             <Appbar />
-            <Sidebar menu_id="2" />
+            <Sidebar menu_id="5" />
             <main className={classes.content}>
                 <div className={classes.toolbar} />
                 <div className={classes.main}>

--- a/src/views/Group.js
+++ b/src/views/Group.js
@@ -255,7 +255,7 @@ function Group() {
                                     <TableRow key={group_id}>
                                         <TableCell style={{ fontSize: '1.1rem', width: '30%' }} component="th" scope="row">{group[0]}</TableCell>
                                         <TableCell style={{ fontSize: '1.1rem', width: '30%', textAlign: 'center' }} component="th" scope="row">{group[1]}</TableCell>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }} align='right'><Link className={classes.link_button} to='/group/edit' state={{ groupInfo: group }}><Button color="primary">Edit</Button></Link> {group[0] === 'public' ? <span id={group_id++}></span> : <Button id={group_id++} color="secondary" onClick={() => handleRemoveAction(group)}>Remove</Button>}</TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }} align='right'><Link className={classes.link_button} to='/groups/edit' state={{ groupInfo: group }}><Button color="primary">Edit</Button></Link> {group[0] === 'public' ? <span id={group_id++}></span> : <Button id={group_id++} color="secondary" onClick={() => handleRemoveAction(group)}>Remove</Button>}</TableCell>
                                     </TableRow>
                                 )}
                             </TableBody>

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -155,7 +155,7 @@ function Home() {
 
     return (
         <div>
-            <div className={classes.root}><Appbar /><Sidebar menu_id="0" /><main className={classes.content}><div className={classes.toolbar} />
+            <div className={classes.root}><Appbar /><Sidebar menu_id="1" /><main className={classes.content}><div className={classes.toolbar} />
                 <div className={classes.main}>
                     <Container className={classes.status_box}>
                         <Grid item xs={12} md={8} lg={9}>

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -161,7 +161,7 @@ function Home() {
                         <Grid item xs={12} md={8} lg={9}>
                             <Paper className={classes.paper}>
                                 <Typography className={classes.paper_title}>Servers</Typography>
-                                <Typography className={classes.paper_content}>{zoneContext === undefined ? 0 : zoneContext['servers'].length + 1}</Typography>
+                                <Typography className={classes.paper_content}>{zoneContext === undefined ? 0 : zoneContext.length}</Typography>
                             </Paper>
                         </Grid>
                         <Grid item xs={12} md={8} lg={9}>
@@ -189,53 +189,7 @@ function Home() {
                             </Paper>
                         </Grid>
                     </Container>
-                    <br />
-                    <Pagination count={1} /><br />{zoneContext !== undefined ?
-                        <Card key={zone_id} className={classes.server_card} id={zone_id}>
-                            <CardHeader
-                                avatar={
-                                    <img alt="Zone Icon" className={classes.server} id={zone_id} src={ServerIcon}></img>
-                                }
-                                title="Server"
-                                subheader="iCAT Server"
-                                action={
-                                    <IconButton
-                                        onClick={handleExpandClick}>
-                                        <ExpandMoreIcon />
-                                    </IconButton>
-                                }
-                            />
-                            <Collapse in={expanded} timeout="auto" unmountOnExit>
-                                <CardContent>
-                                    <Typography paragraph>Hostname: {zoneContext['icat_server']['host_system_information']['hostname']}</Typography>
-                                    <Typography paragraph>OS Distribution Name: {zoneContext['icat_server']['host_system_information']['os_distribution_name']}</Typography>
-                                    <Typography paragraph>OS Distribution Version: {zoneContext['icat_server']['host_system_information']['os_distribution_version']}</Typography>
-                                    <Button onClick={viewDetails} color="primary">Details</Button>
-                                </CardContent>
-                                {details === true ? <Dialog open={details} className={classes.dialog} onClose={closeDetails}>
-                                    <DialogTitle>Server Details</DialogTitle>
-                                    <DialogContent className={classes.server_details}>
-                                        <Tabs orientation="vertical" variant="scrollable" value={tabValue} className={classes.tabs} onChange={handleTabChange} aria-label="vertical tabs example">
-                                            <Tab className={classes.tab} label="Host" {...a11yProps(0)} />
-                                            <Tab className={classes.tab} label="Service" {...a11yProps(1)} />
-                                            <Tab className={classes.tab} label="Plugin" {...a11yProps(2)} />
-                                        </Tabs>
-                                        <TabPanel className={classes.tab_panel} value={tabValue} index={0}>
-                                            <Typography component={'span'} className={classes.info}>Schema Name: {zoneContext['icat_server']['host_access_control_config']['schema_name']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>Schema Version: {zoneContext['icat_server']['host_access_control_config']['schema_version']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>Catalog Schema Version: {zoneContext['icat_server']['version']['catalog_schema_version']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>Configuration Schema Version: {zoneContext['icat_server']['version']['configuration_schema_version']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>iRODS Version: {zoneContext['icat_server']['version']['irods_version']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>Installation Time: {zoneContext['icat_server']['version']['installation_time']}</Typography>
-                                        </TabPanel>
-                                        <TabPanel className={classes.tab_panel} value={tabValue} index={1}>
-                                        </TabPanel>
-                                        <TabPanel className={classes.tab_panel} value={tabValue} index={2}>
-                                        </TabPanel>
-                                    </DialogContent>
-                                </Dialog> : <span />}
-                            </Collapse>
-                        </Card> : <div><CircularProgress /> Loading...</div>}</div></main>
+                    </div></main>
             </div>
         </div >
     );

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -113,7 +113,6 @@ function Home() {
     }
 
     const viewDetails = (event) => {
-        setCurrZone(zoneContext[document.getElementsByClassName(classes.server_card)[0].id]['icat_server']);
         setDetails(true);
     }
 
@@ -191,7 +190,7 @@ function Home() {
                         </Grid>
                     </Container>
                     <br />
-                    <Pagination count={1} /><br />{zoneContext !== undefined ? zoneContext.map((zone_report) =>
+                    <Pagination count={1} /><br />{zoneContext !== undefined ? 
                         <Card key={zone_id} className={classes.server_card} id={zone_id}>
                             <CardHeader
                                 avatar={
@@ -208,9 +207,9 @@ function Home() {
                             />
                             <Collapse in={expanded} timeout="auto" unmountOnExit>
                                 <CardContent>
-                                    <Typography paragraph>Hostname: {zone_report['icat_server']['host_system_information']['hostname']}</Typography>
-                                    <Typography paragraph>OS Distribution Name: {zone_report['icat_server']['host_system_information']['os_distribution_name']}</Typography>
-                                    <Typography paragraph>OS Distribution Version: {zone_report['icat_server']['host_system_information']['os_distribution_version']}</Typography>
+                                    <Typography paragraph>Hostname: {zoneContext['icat_server']['host_system_information']['hostname']}</Typography>
+                                    <Typography paragraph>OS Distribution Name: {zoneContext['icat_server']['host_system_information']['os_distribution_name']}</Typography>
+                                    <Typography paragraph>OS Distribution Version: {zoneContext['icat_server']['host_system_information']['os_distribution_version']}</Typography>
                                     <Button onClick={viewDetails} color="primary">Details</Button>
                                 </CardContent>
                                 {details === true ? <Dialog open={details} className={classes.dialog} onClose={closeDetails}>
@@ -222,33 +221,21 @@ function Home() {
                                             <Tab className={classes.tab} label="Plugin" {...a11yProps(2)} />
                                         </Tabs>
                                         <TabPanel className={classes.tab_panel} value={tabValue} index={0}>
-                                            <Typography component={'span'} className={classes.info}>Schema Name: {curr_zone['host_access_control_config']['schema_name']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>Schema Version: {curr_zone['host_access_control_config']['schema_version']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>Catalog Schema Version: {curr_zone['version']['catalog_schema_version']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>Configuration Schema Version: {curr_zone['version']['configuration_schema_version']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>iRODS Version: {curr_zone['version']['irods_version']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>Installation Time: {curr_zone['version']['installation_time']}</Typography>
+                                            <Typography component={'span'} className={classes.info}>Schema Name: {zoneContext['icat_server']['host_access_control_config']['schema_name']}</Typography>
+                                            <Typography component={'span'} className={classes.info}>Schema Version: {zoneContext['icat_server']['host_access_control_config']['schema_version']}</Typography>
+                                            <Typography component={'span'} className={classes.info}>Catalog Schema Version: {zoneContext['icat_server']['version']['catalog_schema_version']}</Typography>
+                                            <Typography component={'span'} className={classes.info}>Configuration Schema Version: {zoneContext['icat_server']['version']['configuration_schema_version']}</Typography>
+                                            <Typography component={'span'} className={classes.info}>iRODS Version: {zoneContext['icat_server']['version']['irods_version']}</Typography>
+                                            <Typography component={'span'} className={classes.info}>Installation Time: {zoneContext['icat_server']['version']['installation_time']}</Typography>
                                         </TabPanel>
                                         <TabPanel className={classes.tab_panel} value={tabValue} index={1}>
-                                            <Typography component={'span'} className={classes.info}>iRODS Client Server Negotiation: {curr_zone['service_account_environment']['irods_client_server_negotiation']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>iRODS Client Server Policy: {curr_zone['service_account_environment']['irods_client_server_policy']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>iRODS Connection Refresh Time: {curr_zone['service_account_environment']['irods_connection_pool_refresh_time_in_seconds']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>iRODS CWD: {curr_zone['service_account_environment']['irods_cwd']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>iRODS Default Hash Scheme: {curr_zone['service_account_environment']['irods_default_hash_scheme']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>iRODS Default Resource: {curr_zone['service_account_environment']['irods_default_resource']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>iRODS Encryption Algorithm: {curr_zone['service_account_environment']['irods_encryption_algorithm']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>iRODS Encryption Key Size: {curr_zone['service_account_environment']['irods_encryption_key_size']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>iRODS Encryption Hash Rounds: {curr_zone['service_account_environment']['irods_encryption_num_hash_rounds']}</Typography>
-                                            <Typography component={'span'} className={classes.info}>iRODS Encryption Salt Size: {curr_zone['service_account_environment']['irods_encryption_salt_size']}</Typography>
                                         </TabPanel>
                                         <TabPanel className={classes.tab_panel} value={tabValue} index={2}>
-                                            <Typography component={'span'} className={classes.info}>Total number of Plugins: {curr_zone['plugins'].length}</Typography>
                                         </TabPanel>
                                     </DialogContent>
                                 </Dialog> : <span />}
                             </Collapse>
-                        </Card>
-                    ) : <div><CircularProgress /> Loading...</div>}</div></main>
+                        </Card> : <div><CircularProgress /> Loading...</div>}</div></main>
             </div>
         </div >
     );

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -1,16 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import Sidebar from '../components/Sidebar';
 import Appbar from '../components/Appbar';
 import { makeStyles } from '@material-ui/core/styles';
-import ServerIcon from '../img/servers-logo.png';
-import IconButton from '@material-ui/core/IconButton';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
-import Pagination from '@material-ui/lab/Pagination';
-import { Typography, CircularProgress, Container } from '@material-ui/core';
-import { Button, Card, CardHeader, CardContent, Collapse } from '@material-ui/core';
-import { Dialog, DialogContent, DialogTitle } from '@material-ui/core';
-import { Box, Grid, Paper, Tab, Tabs } from '@material-ui/core';
+import { Typography, Container } from '@material-ui/core';
+import { Grid, Paper } from '@material-ui/core';
 import { useServer } from '../contexts/ServerContext';
 import Logout from './Logout';
 
@@ -90,12 +83,7 @@ function Home() {
         return <Logout />
     }
     const { userContext, groupContext, rescContext, zoneContext, loadData } = useServer();
-    const [curr_zone, setCurrZone] = useState();
-    const [details, setDetails] = useState(false);
-    const [expanded, setExpanded] = useState(false);
-    const [tabValue, setTab] = useState(0);
     const classes = useStyles();
-    let zone_id = 0;
 
     const [status, setStatus] = useState()
 
@@ -103,55 +91,6 @@ function Home() {
         loadData();
         setStatus("OK");
     }, [])
-
-    const handleExpandClick = () => {
-        setExpanded(!expanded);
-    }
-
-    const handleTabChange = (event, newValue) => {
-        setTab(newValue);
-    }
-
-    const viewDetails = (event) => {
-        setDetails(true);
-    }
-
-    const closeDetails = (event) => {
-        setDetails(false);
-    }
-
-    function TabPanel(props) {
-        const { children, value, index, ...other } = props;
-
-        return (
-            <div
-                role="tabpanel"
-                hidden={value !== index}
-                id={`simple-tabpanel-${index}`}
-                aria-labelledby={`vertical-tab-${index}`}
-                {...other}
-            >
-                {value === index && (
-                    <Box p={3}>
-                        <Typography>{children}</Typography>
-                    </Box>
-                )}
-            </div>
-        );
-    }
-
-    TabPanel.propTypes = {
-        children: PropTypes.node,
-        index: PropTypes.any.isRequired,
-        value: PropTypes.any.isRequired,
-    };
-
-    function a11yProps(index) {
-        return {
-            id: `simple-tab-${index}`,
-            'aria-controls': `simple-tabpanel-${index}`,
-        };
-    }
 
     return (
         <div>

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -161,7 +161,7 @@ function Home() {
                         <Grid item xs={12} md={8} lg={9}>
                             <Paper className={classes.paper}>
                                 <Typography className={classes.paper_title}>Servers</Typography>
-                                <Typography className={classes.paper_content}>{zoneContext === undefined ? 0 : zoneContext.length}</Typography>
+                                <Typography className={classes.paper_content}>{zoneContext === undefined ? 0 : zoneContext['servers'].length + 1}</Typography>
                             </Paper>
                         </Grid>
                         <Grid item xs={12} md={8} lg={9}>
@@ -190,7 +190,7 @@ function Home() {
                         </Grid>
                     </Container>
                     <br />
-                    <Pagination count={1} /><br />{zoneContext !== undefined ? 
+                    <Pagination count={1} /><br />{zoneContext !== undefined ?
                         <Card key={zone_id} className={classes.server_card} id={zone_id}>
                             <CardHeader
                                 avatar={

--- a/src/views/Server.js
+++ b/src/views/Server.js
@@ -7,7 +7,7 @@ import { useServer } from '../contexts/ServerContext';
 import { makeStyles, Typography } from '@material-ui/core';
 import { Button, FormControl, InputLabel, Select } from '@material-ui/core';
 import { Dialog, DialogContent, DialogTitle } from '@material-ui/core';
-import { Box, Grid, Paper, Tab, Tabs, TabContent } from '@material-ui/core';
+import { Box, Paper, Tab, Tabs } from '@material-ui/core';
 import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TableSortLabel } from '@material-ui/core';
 import Pagination from '@material-ui/lab/Pagination';
 
@@ -158,18 +158,20 @@ function Server() {
                             <Table className={classes.table} aria-label="simple table">
                                 <TableHead>
                                     <TableRow>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>Role</b><TableSortLabel active={orderBy === "role"} direction={orderBy === "role" ? order : 'asc'} onClick={() => { handleSort("role") }} /></TableCell>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }} ><b>Hostname</b><TableSortLabel active={orderBy === "hostname"} direction={orderBy === "hostname" ? order : 'asc'} onClick={() => { handleSort("hostname") }} /></TableCell>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>OS Distribution</b><TableSortLabel active={orderBy === "os"} direction={orderBy === "os" ? order : 'asc'} onClick={() => { handleSort("os") }} /></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '25%' }}><b>Role</b><TableSortLabel active={orderBy === "role"} direction={orderBy === "role" ? order : 'asc'} onClick={() => { handleSort("role") }} /></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '25%' }} ><b>Hostname</b><TableSortLabel active={orderBy === "hostname"} direction={orderBy === "hostname" ? order : 'asc'} onClick={() => { handleSort("hostname") }} /></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '20%' }}><b>Resources</b><TableSortLabel active={orderBy === "resources"} direction={orderBy === "resources" ? order : 'asc'} onClick={() => { handleSort("resources") }} /></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '20%' }}><b>OS Distribution</b><TableSortLabel active={orderBy === "os"} direction={orderBy === "os" ? order : 'asc'} onClick={() => { handleSort("os") }} /></TableCell>
                                         <TableCell style={{ fontSize: '1.1rem', width: '10%' }} align="right"></TableCell>
                                     </TableRow>
                                 </TableHead>
                                 <TableBody>
                                     {filteredServers.map((server) =>
-                                        <TableRow>
-                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{server['server_config']['catalog_service_role'] === 'provider' ? "Catalog Service Provider" : "Catalog Service Consumer"}</TableCell>
-                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{server['host_system_information']['hostname']}</TableCell>
-                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{server['host_system_information']['os_distribution_name'] + " " + server['host_system_information']['os_distribution_version']}</TableCell>
+                                        <TableRow key={server['host_system_information']['hostname']}>
+                                            <TableCell style={{ fontSize: '1.1rem', width: '25%' }}>{server['server_config']['catalog_service_role'] === 'provider' ? "Catalog Service Provider" : "Catalog Service Consumer"}</TableCell>
+                                            <TableCell style={{ fontSize: '1.1rem', width: '25%' }}>{server['host_system_information']['hostname']}</TableCell>
+                                            <TableCell style={{ fontSize: '1.1rem', width: '20%' }}>{server['resources']}</TableCell>
+                                            <TableCell style={{ fontSize: '1.1rem', width: '20%' }}>{server['host_system_information']['os_distribution_name'] + " " + server['host_system_information']['os_distribution_version']}</TableCell>
                                             <TableCell style={{ fontSize: '1.1rem', width: '10%' }} align='right'><Button color="primary" onClick={() => { setCurrServer(server); setOpenDetails(true); }}>Details</Button></TableCell>
                                         </TableRow>
                                     )}

--- a/src/views/Server.js
+++ b/src/views/Server.js
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import Logout from './Logout';
+import Appbar from '../components/Appbar';
+import Sidebar from '../components/Sidebar';
+import { useServer } from '../contexts/ServerContext';
+import { makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles((theme) => ({
+    root: {
+        display: 'flex',
+    },
+    toolbar: theme.mixins.toolbar,
+    content: {
+        flexGrow: 1,
+        backgroundColor: theme.palette.background.default,
+        padding: theme.spacing(3),
+    },
+    main: {
+        whiteSpace: "pre-wrap",
+        fontSize: 20
+    }
+}))
+
+function Server() {
+    const auth = localStorage.getItem('zmt-token');
+    if (auth === null) {
+        return <Logout />
+    }
+    const classes = useStyles();
+    const { serverContext } = useServer();
+    return (
+        <div className={classes.root}>
+            <Appbar />
+            <Sidebar menu_id="2" />
+            <main className={classes.content}>
+                <div className={classes.toolbar} />
+                <div className={classes.main}>
+                    server page
+                </div>
+            </main>
+        </div>
+    )
+}
+
+export default Server;

--- a/src/views/Server.js
+++ b/src/views/Server.js
@@ -46,6 +46,9 @@ const useStyles = makeStyles((theme) => ({
         margin: theme.spacing(1),
         fontSize: 14
     },
+    plugin_info: {
+        fontSize: 14
+    },
     server: {
         width: theme.spacing(8)
     },
@@ -143,7 +146,7 @@ function Server() {
                             <Table className={classes.table} aria-label="simple table">
                                 <TableHead>
                                     <TableRow>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>Type</b></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>Role</b></TableCell>
                                         <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>Hostname</b></TableCell>
                                         <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>OS Distribution</b></TableCell>
                                         <TableCell style={{ fontSize: '1.1rem', width: '10%' }} align="right"></TableCell>
@@ -151,16 +154,17 @@ function Server() {
                                 </TableHead>
                                 <TableBody>
                                     <TableRow>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>iCAT Server</TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>Catalog Service Provider</TableCell>
                                         <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{zoneContext['icat_server']['host_system_information']['hostname']}</TableCell>
                                         <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{zoneContext['icat_server']['host_system_information']['os_distribution_name'] + " " + zoneContext['icat_server']['host_system_information']['os_distribution_version']}</TableCell>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '10%' }} align='right'><Button color="primary" onClick={() => { setCurrServer(zoneContext['icat_server']); setOpenDetails(true); }}>Stats</Button></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '10%' }} align='right'><Button color="primary" onClick={() => { setCurrServer(zoneContext['icat_server']); setOpenDetails(true); }}>Details</Button></TableCell>
                                     </TableRow>
                                     {zoneContext.servers.map((server) =>
                                         <TableRow>
+                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>Catalog Service Consumer</TableCell>
                                             <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{server['icat_server']['host_system_information']['hostname']}</TableCell>
                                             <TableCell style={{ fontSize: '1.1rem', width: '30%' }} align='right'>{server['icat_server']['host_system_information']['os_distribution_name'] + " " + server['icat_server']['host_system_information']['os_distribution_version']}</TableCell>
-                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }} align='right'><Button color="primary" onClick={() => { setCurrServer(server); setOpenDetails(true); }}>Stats</Button></TableCell>
+                                            <TableCell style={{ fontSize: '1.1rem', width: '10%' }} align='right'><Button color="primary" onClick={() => { setCurrServer(server); setOpenDetails(true); }}>Details</Button></TableCell>
                                         </TableRow>
                                     )}
                                 </TableBody>
@@ -223,7 +227,7 @@ function Server() {
                                     <TabPanel className={classes.tab_panel} value={tabValue} index={3}>
                                         <div>
                                             <tr><td><b>Name</b></td><td><b>Type</b></td></tr>
-                                            {currServer['plugins'].map(plugin => <tr><td><div className={classes.info}>{plugin.name}</div></td><td><div className={classes.info}>{plugin.type}</div></td></tr>)}
+                                            {currServer['plugins'].map(plugin => <tr><td><div className={classes.plugin_info}>{plugin.name}</div></td><td><div className={classes.info}>{plugin.type}</div></td></tr>)}
                                         </div>
                                     </TabPanel>
                                 </DialogContent>

--- a/src/views/Server.js
+++ b/src/views/Server.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import Logout from './Logout';
 import Appbar from '../components/Appbar';
@@ -77,12 +77,16 @@ function Server() {
         return <Logout />
     }
     const classes = useStyles();
-    const { zoneContext } = useServer();
-    const [currPage, setCurrPage] = useState();
+    const { zoneContext, filteredServers, loadCurrServer } = useServer();
+    const [currPage, setCurrPage] = useState(1);
     const [perPage, setPerPage] = useState(10);
     const [tabValue, setTabValue] = useState(0);
     const [openDetails, setOpenDetails] = useState(false);
     const [currServer, setCurrServer] = useState();
+
+    useEffect(() => {
+        loadCurrServer(perPage * (currPage - 1), perPage * currPage);
+    }, [perPage, currPage])
 
     function TabPanel(props) {
         const { children, value, index, ...other } = props;
@@ -153,17 +157,11 @@ function Server() {
                                     </TableRow>
                                 </TableHead>
                                 <TableBody>
-                                    <TableRow>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>Catalog Service Provider</TableCell>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{zoneContext['icat_server']['host_system_information']['hostname']}</TableCell>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{zoneContext['icat_server']['host_system_information']['os_distribution_name'] + " " + zoneContext['icat_server']['host_system_information']['os_distribution_version']}</TableCell>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '10%' }} align='right'><Button color="primary" onClick={() => { setCurrServer(zoneContext['icat_server']); setOpenDetails(true); }}>Details</Button></TableCell>
-                                    </TableRow>
-                                    {zoneContext.servers.map((server) =>
+                                    {filteredServers.map((server) =>
                                         <TableRow>
-                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>Catalog Service Consumer</TableCell>
-                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{server['icat_server']['host_system_information']['hostname']}</TableCell>
-                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }} align='right'>{server['icat_server']['host_system_information']['os_distribution_name'] + " " + server['icat_server']['host_system_information']['os_distribution_version']}</TableCell>
+                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{server['server_config']['catalog_service_role'] === 'provider' ? "Catalog Service Provider" : "Catalog Service Consumer"}</TableCell>
+                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{server['host_system_information']['hostname']}</TableCell>
+                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{server['host_system_information']['os_distribution_name'] + " " + server['host_system_information']['os_distribution_version']}</TableCell>
                                             <TableCell style={{ fontSize: '1.1rem', width: '10%' }} align='right'><Button color="primary" onClick={() => { setCurrServer(server); setOpenDetails(true); }}>Details</Button></TableCell>
                                         </TableRow>
                                     )}

--- a/src/views/Server.js
+++ b/src/views/Server.js
@@ -168,7 +168,7 @@ function Server() {
                                 <TableBody>
                                     {filteredServers.map((server) =>
                                         <TableRow key={server['host_system_information']['hostname']}>
-                                            <TableCell style={{ fontSize: '1.1rem', width: '25%' }}>{server['server_config']['catalog_service_role'] === 'provider' ? "Catalog Service Provider" : "Catalog Service Consumer"}</TableCell>
+                                            <TableCell style={{ padding: 0, fontSize: '1.1rem', width: '25%' }}><div className="server_role_container"><div className={`server_${server['server_config']['catalog_service_role']}`} />{server['server_config']['catalog_service_role'] === 'provider' ? "Catalog Service Provider" : "Catalog Service Consumer"}</div></TableCell>
                                             <TableCell style={{ fontSize: '1.1rem', width: '25%' }}>{server['host_system_information']['hostname']}</TableCell>
                                             <TableCell style={{ fontSize: '1.1rem', width: '20%' }}>{server['resources']}</TableCell>
                                             <TableCell style={{ fontSize: '1.1rem', width: '20%' }}>{server['host_system_information']['os_distribution_name'] + " " + server['host_system_information']['os_distribution_version']}</TableCell>

--- a/src/views/Server.js
+++ b/src/views/Server.js
@@ -4,6 +4,10 @@ import Appbar from '../components/Appbar';
 import Sidebar from '../components/Sidebar';
 import { useServer } from '../contexts/ServerContext';
 import { makeStyles } from '@material-ui/core';
+import { Button, FormControl, InputLabel, Select } from '@material-ui/core';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TableSortLabel, Paper } from '@material-ui/core';
+import Pagination from '@material-ui/lab/Pagination';
+
 
 const useStyles = makeStyles((theme) => ({
     root: {
@@ -18,6 +22,19 @@ const useStyles = makeStyles((theme) => ({
     main: {
         whiteSpace: "pre-wrap",
         fontSize: 20
+    },
+    pagination: {
+        display: 'flex',
+        flexDirection: 'row',
+        margin: theme.spacing(1),
+        justifyContent: 'center'
+    },
+    pagination_item: {
+        transitionDuration: '1.5s'
+    },
+    itemsControl: {
+        marginLeft: 30,
+        minWidth: 120
     }
 }))
 
@@ -27,16 +44,56 @@ function Server() {
         return <Logout />
     }
     const classes = useStyles();
-    const { serverContext } = useServer();
+    const { zoneContext } = useServer();
+    const [currPage, setCurrPage] = useState();
+    const [perPage, setPerPage] = useState(10);
+
     return (
         <div className={classes.root}>
             <Appbar />
             <Sidebar menu_id="2" />
             <main className={classes.content}>
                 <div className={classes.toolbar} />
-                <div className={classes.main}>
-                    server page
-                </div>
+                {zoneContext === undefined ? <div /> :
+                    <div className={classes.main}>
+                        <div className={classes.pagination}>
+                            <Pagination className={classes.pagination_item} count={Math.ceil(zoneContext.length / perPage)} onChange={(e) => setCurrPage(e.target.value)} />
+                            <FormControl className={classes.itemsControl}>
+                                <InputLabel htmlFor="items-per-page">Items Per Page</InputLabel>
+                                <Select
+                                    native
+                                    id="items-per-page"
+                                    label="Items Per Page"
+                                    onChange={(event) => { setPerPage(event.target.value); setCurrPage(1); }}
+                                >
+                                    <option value="10">10</option>
+                                    <option value="25">25</option>
+                                    <option value="50">50</option>
+                                    <option value="100">100</option>
+                                </Select>
+                            </FormControl>
+                        </div>
+                        <TableContainer className={classes.tableContainer} component={Paper}>
+                            <Table className={classes.table} aria-label="simple table">
+                                <TableHead>
+                                    <TableRow>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>Hostname</b></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }} align="right"><b>OS Distribution</b></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }} align="right"></TableCell>
+                                    </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                    {zoneContext.map((server) =>
+                                        <TableRow>
+                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{server['icat_server']['host_system_information']['hostname']}</TableCell>
+                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }} align='right'>{server['icat_server']['host_system_information']['os_distribution_name'] +" "+server['icat_server']['host_system_information']['os_distribution_version']}</TableCell>
+                                        </TableRow>
+                                    )}
+                                </TableBody>
+                            </Table>
+                        </TableContainer>
+                    </div>
+                }
             </main>
         </div>
     )

--- a/src/views/Server.js
+++ b/src/views/Server.js
@@ -1,11 +1,14 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import Logout from './Logout';
 import Appbar from '../components/Appbar';
 import Sidebar from '../components/Sidebar';
 import { useServer } from '../contexts/ServerContext';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles, Typography } from '@material-ui/core';
 import { Button, FormControl, InputLabel, Select } from '@material-ui/core';
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TableSortLabel, Paper } from '@material-ui/core';
+import { Dialog, DialogContent, DialogTitle } from '@material-ui/core';
+import { Box, Grid, Paper, Tab, Tabs, TabContent } from '@material-ui/core';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TableSortLabel } from '@material-ui/core';
 import Pagination from '@material-ui/lab/Pagination';
 
 
@@ -35,6 +38,33 @@ const useStyles = makeStyles((theme) => ({
     itemsControl: {
         marginLeft: 30,
         minWidth: 120
+    },
+    tab_panel: {
+        width: 700,
+    },
+    info: {
+        margin: theme.spacing(1),
+        fontSize: 14
+    },
+    server: {
+        width: theme.spacing(8)
+    },
+    server_card: {
+        width: theme.spacing(40),
+    },
+    server_details: {
+        flexGrow: 1,
+        display: 'flex',
+        height: 600,
+        padding: 0
+    },
+    tabs: {
+        width: 250,
+    },
+    tab: {
+        marginTop: 20,
+        textTransform: 'none',
+        fontSize: 15
     }
 }))
 
@@ -47,6 +77,42 @@ function Server() {
     const { zoneContext } = useServer();
     const [currPage, setCurrPage] = useState();
     const [perPage, setPerPage] = useState(10);
+    const [tabValue, setTabValue] = useState(0);
+    const [openDetails, setOpenDetails] = useState(false);
+    const [currServer, setCurrServer] = useState();
+
+    function TabPanel(props) {
+        const { children, value, index, ...other } = props;
+
+        return (
+            <div
+                role="tabpanel"
+                hidden={value !== index}
+                id={`simple-tabpanel-${index}`}
+                aria-labelledby={`vertical-tab-${index}`}
+                {...other}
+            >
+                {value === index && (
+                    <Box p={1}>
+                        <Typography>{children}</Typography>
+                    </Box>
+                )}
+            </div>
+        );
+    }
+
+    TabPanel.propTypes = {
+        children: PropTypes.node,
+        index: PropTypes.any.isRequired,
+        value: PropTypes.any.isRequired,
+    };
+
+    function a11yProps(index) {
+        return {
+            id: `simple-tab-${index}`,
+            'aria-controls': `simple-tabpanel-${index}`,
+        };
+    }
 
     return (
         <div className={classes.root}>
@@ -77,21 +143,92 @@ function Server() {
                             <Table className={classes.table} aria-label="simple table">
                                 <TableHead>
                                     <TableRow>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>Type</b></TableCell>
                                         <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>Hostname</b></TableCell>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }} align="right"><b>OS Distribution</b></TableCell>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }} align="right"></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>OS Distribution</b></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '10%' }} align="right"></TableCell>
                                     </TableRow>
                                 </TableHead>
                                 <TableBody>
-                                    {zoneContext.map((server) =>
+                                    <TableRow>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>iCAT Server</TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{zoneContext['icat_server']['host_system_information']['hostname']}</TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{zoneContext['icat_server']['host_system_information']['os_distribution_name'] + " " + zoneContext['icat_server']['host_system_information']['os_distribution_version']}</TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '10%' }} align='right'><Button color="primary" onClick={() => { setCurrServer(zoneContext['icat_server']); setOpenDetails(true); }}>Stats</Button></TableCell>
+                                    </TableRow>
+                                    {zoneContext.servers.map((server) =>
                                         <TableRow>
                                             <TableCell style={{ fontSize: '1.1rem', width: '30%' }}>{server['icat_server']['host_system_information']['hostname']}</TableCell>
-                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }} align='right'>{server['icat_server']['host_system_information']['os_distribution_name'] +" "+server['icat_server']['host_system_information']['os_distribution_version']}</TableCell>
+                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }} align='right'>{server['icat_server']['host_system_information']['os_distribution_name'] + " " + server['icat_server']['host_system_information']['os_distribution_version']}</TableCell>
+                                            <TableCell style={{ fontSize: '1.1rem', width: '30%' }} align='right'><Button color="primary" onClick={() => { setCurrServer(server); setOpenDetails(true); }}>Stats</Button></TableCell>
                                         </TableRow>
                                     )}
                                 </TableBody>
                             </Table>
-                        </TableContainer>
+                        </TableContainer>{currServer !== undefined &&
+                            <Dialog open={openDetails} className={classes.dialog} onClose={() => setOpenDetails(false)}>
+                                <DialogTitle>Server Details</DialogTitle>
+                                <DialogContent className={classes.server_details}>
+                                    <Tabs orientation="vertical" variant="scrollable" value={tabValue} className={classes.tabs} onChange={(event, newValue) => setTabValue(newValue)} aria-label="vertical tabs example">
+                                        <Tab className={classes.tab} label="General" {...a11yProps(0)} />
+                                        <Tab className={classes.tab} label="Service Configuration" {...a11yProps(1)} />
+                                        <Tab className={classes.tab} label="Service Account Environment" {...a11yProps(2)} />
+                                        <Tab className={classes.tab} label={<React.Fragment><span>Plugin ({currServer['plugins'].length})</span></React.Fragment>} {...a11yProps(3)} />
+                                    </Tabs>
+                                    <TabPanel className={classes.tab_panel} value={tabValue} index={0}>
+                                        <p className={classes.info}>Hostname: {currServer['host_system_information']['hostname']}</p>
+                                        <p className={classes.info}>OS Distribution Name: {currServer['host_system_information']['os_distribution_name']}</p>
+                                        <p className={classes.info}>OS Distribution Version: {currServer['host_system_information']['os_distribution_version']}</p>
+                                        <p className={classes.info}>Service Account Group Name: {currServer['host_system_information']['service_account_group_name']}</p>
+                                        <p className={classes.info}>Service Account User Name: {currServer['host_system_information']['service_account_user_name']}</p>
+                                        <p className={classes.info}>Schema Name: {currServer['host_access_control_config']['schema_name']}</p>
+                                        <p className={classes.info}>Schema Version: {currServer['host_access_control_config']['schema_version']}</p>
+                                        <p className={classes.info}>Catalog Schema Version: {currServer['version']['catalog_schema_version']}</p>
+                                        <p className={classes.info}>Configuration Schema Version: {currServer['version']['configuration_schema_version']}</p>
+                                        <p className={classes.info}>iRODS Version: {currServer['version']['irods_version']}</p>
+                                        <p className={classes.info}>Installation Time: {currServer['version']['installation_time']}</p>
+                                    </TabPanel>
+                                    <TabPanel className={classes.tab_panel} value={tabValue} index={1}>
+                                        <div className={classes.info}>Catalog Provider Hosts: {currServer['server_config']['catalog_provider_hosts']}</div>
+                                        <div className={classes.info}>Catalog Service Role: {currServer['server_config']['catalog_service_role']}</div>
+                                        <div className={classes.info}>Client Api Whitelist Policy: {currServer['server_config']['client_api_whitelist_policy']}</div>
+                                        <div className={classes.info}>Default Dir Mode: {currServer['server_config']['default_dir_mode']}</div>
+                                        <div className={classes.info}>Default File Mode: {currServer['server_config']['default_file_mode']}</div>
+                                        <div className={classes.info}>Default Hash Scheme: {currServer['server_config']['default_hash_scheme']}</div>
+                                        <div className={classes.info}>Default Resource Name: {currServer['server_config']['default_resource_name']}</div>
+                                        <div className={classes.info}>Match Hash Policy: {currServer['server_config']['match_hash_policy']}</div>
+                                        <div className={classes.info}>Server Control Plane Encryption Algorithm: {currServer['server_config']['server_control_plane_encryption_algorithm']}</div>
+                                        <div className={classes.info}>Server Control Plane Encryption Num Hash Rounds: {currServer['server_config']['server_control_plane_encryption_num_hash_rounds']}</div>
+                                        <div className={classes.info}>Server Control Plane Port: {currServer['server_config']['server_control_plane_port']}</div>
+                                        <div className={classes.info}>Server Port Range: {currServer['server_config']['server_port_range_start']} ~ {currServer['server_config']['server_port_range_end']}</div>
+                                        <div className={classes.info}>XMSG Port: {currServer['server_config']['xmsg_port']}</div>
+                                        <div className={classes.info}>Zone Auth Scheme: {currServer['server_config']['zone_auth_scheme']}</div>
+                                        <div className={classes.info}>Zone Port: {currServer['server_config']['zone_port']}</div>
+                                        <div className={classes.info}>Zone User: {currServer['server_config']['zone_user']}</div>
+                                    </TabPanel>
+                                    <TabPanel className={classes.tab_panel} value={tabValue} index={2}>
+                                        <div className={classes.info}>iRODS Client Server Negotiation: {currServer['service_account_environment']['irods_client_server_negotiation']}</div>
+                                        <div className={classes.info}>iRODS Client Server Policy: {currServer['service_account_environment']['irods_client_server_policy']}</div>
+                                        <div className={classes.info}>iRODS Connection Refresh Time: {currServer['service_account_environment']['irods_connection_pool_refresh_time_in_seconds']}</div>
+                                        <div className={classes.info}>iRODS CWD: {currServer['service_account_environment']['irods_cwd']}</div>
+                                        <div className={classes.info}>iRODS Default Hash Scheme: {currServer['service_account_environment']['irods_default_hash_scheme']}</div>
+                                        <div className={classes.info}>iRODS Default Resource: {currServer['service_account_environment']['irods_default_resource']}</div>
+                                        <div className={classes.info}>iRODS Encryption Algorithm: {currServer['service_account_environment']['irods_encryption_algorithm']}</div>
+                                        <div className={classes.info}>iRODS Encryption Key Size: {currServer['service_account_environment']['irods_encryption_key_size']}</div>
+                                        <div className={classes.info}>iRODS Encryption Hash Rounds: {currServer['service_account_environment']['irods_encryption_num_hash_rounds']}</div>
+                                        <div className={classes.info}>iRODS Encryption Salt Size: {currServer['service_account_environment']['irods_encryption_salt_size']}</div>
+                                        <div className={classes.info}>iRODS Home: {currServer['service_account_environment']['irods_home']}</div>
+                                        <div className={classes.info}>iRODS Maximum Size for Single Buffer In Megabytes: {currServer['service_account_environment']['irods_maximum_size_for_single_buffer_in_megabytes']}</div>
+                                    </TabPanel>
+                                    <TabPanel className={classes.tab_panel} value={tabValue} index={3}>
+                                        <div>
+                                            <tr><td><b>Name</b></td><td><b>Type</b></td></tr>
+                                            {currServer['plugins'].map(plugin => <tr><td><div className={classes.info}>{plugin.name}</div></td><td><div className={classes.info}>{plugin.type}</div></td></tr>)}
+                                        </div>
+                                    </TabPanel>
+                                </DialogContent>
+                            </Dialog>
+                        }
                     </div>
                 }
             </main>

--- a/src/views/Server.js
+++ b/src/views/Server.js
@@ -83,10 +83,18 @@ function Server() {
     const [tabValue, setTabValue] = useState(0);
     const [openDetails, setOpenDetails] = useState(false);
     const [currServer, setCurrServer] = useState();
+    const [order, setOrder] = useState("asc");
+    const [orderBy, setOrderBy] = useState("role");
 
     useEffect(() => {
-        loadCurrServer(perPage * (currPage - 1), perPage * currPage);
-    }, [perPage, currPage])
+        loadCurrServer(perPage * (currPage - 1), perPage * currPage, order, orderBy);
+    }, [perPage, currPage, order, orderBy])
+
+    const handleSort = props => {
+        const isAsc = orderBy === props && order === 'desc';
+        setOrder(isAsc ? 'asc' : 'desc');
+        setOrderBy(props);
+    }
 
     function TabPanel(props) {
         const { children, value, index, ...other } = props;
@@ -150,9 +158,9 @@ function Server() {
                             <Table className={classes.table} aria-label="simple table">
                                 <TableHead>
                                     <TableRow>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>Role</b></TableCell>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>Hostname</b></TableCell>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>OS Distribution</b></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>Role</b><TableSortLabel active={orderBy === "role"} direction={orderBy === "role" ? order : 'asc'} onClick={() => { handleSort("role") }} /></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }} ><b>Hostname</b><TableSortLabel active={orderBy === "hostname"} direction={orderBy === "hostname" ? order : 'asc'} onClick={() => { handleSort("hostname") }} /></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '30%' }}><b>OS Distribution</b><TableSortLabel active={orderBy === "os"} direction={orderBy === "os" ? order : 'asc'} onClick={() => { handleSort("os") }} /></TableCell>
                                         <TableCell style={{ fontSize: '1.1rem', width: '10%' }} align="right"></TableCell>
                                     </TableRow>
                                 </TableHead>

--- a/src/views/User.js
+++ b/src/views/User.js
@@ -257,7 +257,7 @@ function User() {
                                     <TableRow key={this_user[0]}>
                                         <TableCell style={{ fontSize: '1.1rem', width: '20%' }} component="th" scope="row">{this_user[0]}</TableCell>
                                         <TableCell style={{ fontSize: '1.1rem', width: '20%' }} align="right">{this_user[1]}</TableCell>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '20%' }} align="right"> {(this_user[0] === 'rods' || this_user[0] === 'public') ? <p></p> : <span><Link className={classes.link_button} to='/user/edit' state={{ userInfo: this_user }}><Button color="primary">Edit</Button></Link>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '20%' }} align="right"> {(this_user[0] === 'rods' || this_user[0] === 'public') ? <p></p> : <span><Link className={classes.link_button} to='/users/edit' state={{ userInfo: this_user }}><Button color="primary">Edit</Button></Link>
                                             <Button color="secondary" onClick={() => { handleRemoveConfirmationOpen(this_user) }}>Remove</Button></span>}</TableCell>
                                     </TableRow>
                                 ) : <span />}

--- a/src/views/User.js
+++ b/src/views/User.js
@@ -200,7 +200,7 @@ function User() {
     return (
         <div className={classes.root}>
             <Appbar />
-            <Sidebar menu_id="1" />
+            <Sidebar menu_id="4" />
             <main className={classes.content}>
                 <div className={classes.toolbar} />
                 <div className={classes.main}>


### PR DESCRIPTION
This pr features:
- added new server listing tableview, with table column of server role, ip address, resources, os and a detail button, which will pop up a new dialog to show all server details
- got rid of the old server component on homepage. Homepage appears to be empty right now, we can think of adding more or do we need the homepage, as the only stuff right now are the counts of users/groups/resources which are available in the sidebar as well.
- implemented sorting function in the server context provider which can be apply to ip, resources counts, role and os. I setup a helper function to compare different ip address and I think it should work in all cases. Let me know if that is a good approach or not!
- each server row will have a different color vertical bar at the beginning indicating its role, grey for consumer and light irods green for provider.

I am still poking around the resource parent and how we can display those relationships. Will include them in future pr.

Attached a screenshot here, let me know your thoughts on those. Happy to hop on a call if that would be helpful!


![image](https://user-images.githubusercontent.com/33065086/115924056-31ceb700-a44d-11eb-81e8-5aa50087b968.png)
