### PR TITLE
[54] Add irods version column and support its sorting

### DIFF
--- a/src/contexts/ServerContext.js
+++ b/src/contexts/ServerContext.js
@@ -174,13 +174,25 @@ export const ServerProvider = ({ children }) => {
             let fullServersArray = catalog_service_provider.concat(zone_report.data.zones[0]['servers']);
             for (let curr_server of fullServersArray) {
                 let resource_counts = await fetchServerResources(curr_server['host_system_information']['hostname'])
-                if(resource_counts === undefined) curr_server["resources"] = 0;
+                if (resource_counts === undefined) curr_server["resources"] = 0;
                 else curr_server["resources"] = resource_counts.data.total;
             }
             setZoneContext(fullServersArray)
             setFilteredServers(fullServersArray.slice(0, 10));
             setIsLoadingZoneContext(false);
         }
+    }
+
+    // designed to compare different irods version (e.g. 4.2.10 > 4.2.8)
+    const irodsVersionComparator = (a, b) => {
+        let aa = a.split('.').map(Number);
+        let bb = b.split('.').map(Number);
+        let r = 0;
+        let l = Math.max(aa.length, bb.length)
+        for (let i = 0; !r && i < l; i++) {
+            r = (aa[i] || 0) - (bb[i] || 0)
+        }
+        return r;
     }
 
     // handle servers page pagination and sorting
@@ -199,6 +211,8 @@ export const ServerProvider = ({ children }) => {
                         return orderSyntax * ((a['host_system_information']['os_distribution_name'] + a['host_system_information']['os_distribution_version']).localeCompare((b['host_system_information']['os_distribution_name'] + b['host_system_information']['os_distribution_version'])))
                     case 'resources':
                         return orderSyntax * (a['resources'] - b['resources'])
+                    case 'irods-version':
+                        return orderSyntax * irodsVersionComparator(a['version']['irods_version'], b['version']['irods_version'])
                     default:
                         return orderSyntax * (a['server_config']['catalog_service_role'].localeCompare(b['server_config']['catalog_service_role']));
                 }

--- a/src/views/Server.js
+++ b/src/views/Server.js
@@ -83,20 +83,22 @@ export const Server = () => {
                             <TableHead>
                                 <TableRow>
                                     <TableCell style={{ fontSize: '1.1rem', width: '25%' }}><b>Role</b><TableSortLabel active={orderBy === "role"} direction={orderBy === "role" ? order : 'asc'} onClick={() => { handleSort("role") }} /></TableCell>
+                                    <TableCell style={{ fontSize: '1.1rem', width: '15%' }}><b>iRODS Version</b><TableSortLabel active={orderBy === "irods-version"} direction={orderBy === "irods-version" ? order : 'asc'} onClick={() => { handleSort("irods-version") }} /></TableCell>
                                     <TableCell style={{ fontSize: '1.1rem', width: '25%' }} ><b>Hostname</b><TableSortLabel active={orderBy === "hostname"} direction={orderBy === "hostname" ? order : 'asc'} onClick={() => { handleSort("hostname") }} /></TableCell>
-                                    <TableCell style={{ fontSize: '1.1rem', width: '20%' }}><b>Resources</b><TableSortLabel active={orderBy === "resources"} direction={orderBy === "resources" ? order : 'asc'} onClick={() => { handleSort("resources") }} /></TableCell>
+                                    <TableCell style={{ fontSize: '1.1rem', width: '10%' }}><b>Resources</b><TableSortLabel active={orderBy === "resources"} direction={orderBy === "resources" ? order : 'asc'} onClick={() => { handleSort("resources") }} /></TableCell>
                                     <TableCell style={{ fontSize: '1.1rem', width: '20%' }}><b>OS Distribution</b><TableSortLabel active={orderBy === "os"} direction={orderBy === "os" ? order : 'asc'} onClick={() => { handleSort("os") }} /></TableCell>
-                                    <TableCell style={{ fontSize: '1.1rem', width: '10%' }} align="right"></TableCell>
+                                    <TableCell style={{ fontSize: '1.1rem', width: '5%' }} align="right"></TableCell>
                                 </TableRow>
                             </TableHead>
                             <TableBody>
                                 {filteredServers.map((server) =>
                                     <TableRow key={server['host_system_information']['hostname']}>
                                         <TableCell style={{ padding: 0, fontSize: '1.1rem', width: '25%' }}><div className="server_role_container"><div className={`server_${server['server_config']['catalog_service_role']}`} />{server['server_config']['catalog_service_role'] === 'provider' ? "Catalog Service Provider" : "Catalog Service Consumer"}</div></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '15%' }}>{server['version']['irods_version']}</TableCell>
                                         <TableCell style={{ fontSize: '1.1rem', width: '25%' }}>{server['host_system_information']['hostname']}</TableCell>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '20%' }}>{server['resources']}</TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '10%' }}>{server['resources']}</TableCell>
                                         <TableCell style={{ fontSize: '1.1rem', width: '20%' }}>{server['host_system_information']['os_distribution_name'] + " " + server['host_system_information']['os_distribution_version']}</TableCell>
-                                        <TableCell style={{ fontSize: '1.1rem', width: '10%' }} align='right'><Button color="primary" onClick={() => { setCurrServer(server); setOpenDetails(true); }}>Details</Button></TableCell>
+                                        <TableCell style={{ fontSize: '1.1rem', width: '5%' }} align='right'><Button color="primary" onClick={() => { setCurrServer(server); setOpenDetails(true); }}>Details</Button></TableCell>
                                     </TableRow>
                                 )}
                             </TableBody>


### PR DESCRIPTION
This pr 
- added a new column to display server's irods version
- designed a custom comparator to sort irods version. We cannot use in-built localeCompare here as it can only sort those string alphabetically, which means 4.2.8 > 4.2.10.

![image](https://user-images.githubusercontent.com/33065086/131736338-938f9d73-b9bc-44c2-931e-eed20711c95f.png)
