### PR TITLE
Refactor/resource editing

### DIFF
--- a/src/contexts/ServerContext.js
+++ b/src/contexts/ServerContext.js
@@ -31,6 +31,7 @@ export const ServerProvider = ({ children }) => {
     const [rescTypes, setRescTypes] = useState([]);
     const [rescTotal, setRescTotal] = useState(0);
     const [isLoadingRescContext, setIsLoadingRescContext] = useState(false);
+    const [editingRescID, setEditingRescID] = useState();
     const [filteredServers, setFilteredServers] = useState();
 
     const loadUser = (offset, limit, name, order, orderBy) => {
@@ -122,6 +123,10 @@ export const ServerProvider = ({ children }) => {
             setIsLoadingRescContext(false);
         });
     }, [restApiLocation])
+
+    const editingResource = (id) => {
+        setEditingRescID(id);
+    }
 
     const loadZoneName = () => {
         return axios({
@@ -260,7 +265,7 @@ export const ServerProvider = ({ children }) => {
             zoneContext, zoneName, loadZoneName, loadZoneReport, filteredServers, loadCurrServer,
             userTotal, userContext, loadUser,
             groupTotal, groupContext, loadGroup,
-            rescTotal, rescContext, rescTypes, loadResource,
+            rescTotal, rescContext, rescTypes, editingRescID, editingResource, loadResource,
             isLoadingGroupContext, isLoadingRescContext, isLoadingUserContext, isLoadingZoneContext,
             loadData
         }}>


### PR DESCRIPTION
This pr
- refactored the resource editor mode, one edit/save button for one resource, so admin can edit multiple fields and submit at one time (zmt will still do async calls, e.g. update `comment` first and then `context string`..)
- added new notifications at the bottom and prevent the page from refreshing when an edit is successful (if that notification looks good, I can let other pages have that as well so it's consistent
- support key event, press enter will do the same as clicking save button.

A few screenshots:

Normal detail view:
![image](https://user-images.githubusercontent.com/33065086/132014688-f8d7efa0-e990-46a8-861e-ca1fdb4fd9c7.png)

Editor mode:
![image](https://user-images.githubusercontent.com/33065086/132014803-8d103708-c065-4985-94c3-56a4cf50e2a7.png)
(save button will be disabled/grey out until you make changes)

Notification:
![image](https://user-images.githubusercontent.com/33065086/132015243-769ad4e3-bbea-4712-afc7-26e0930fffa2.png)

Is that a good approach?
