### PR TITLE
[85] Add new user management interface

### DIFF
--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -76,8 +76,9 @@ export const Layout = ({ children }) => {
 
     const logoutHandler = () => {
         localStorage.removeItem('zmt-token');
-        localStorage.removeItem('zmt-inactiveChecks') 
-        localStorage.removeItem('zmt-checkIntervals') 
+        localStorage.removeItem('zmt-username');
+        localStorage.removeItem('zmt-inactiveChecks'); 
+        localStorage.removeItem('zmt-checkIntervals');
         navigate('/');
     }
 

--- a/src/views/Authenticate.js
+++ b/src/views/Authenticate.js
@@ -67,6 +67,7 @@ export const Authenticate = () => {
             }).then((res) => {
                 if (res.status === 200) {
                     localStorage.setItem('zmt-token', res.data);
+                    localStorage.setItem('zmt-username', username);
                     navigate('/home', { replace: true });
                     renderLayout();
                     loadData();

--- a/src/views/User.js
+++ b/src/views/User.js
@@ -52,6 +52,7 @@ export const User = () => {
     const params = new URLSearchParams(location.search)
     const { restApiLocation } = useEnvironment();
     const auth = localStorage.getItem('zmt-token');
+    const loggedUserName = localStorage.getItem('zmt-username');
     const classes = useStyles();
     const [currUser, setCurrUser] = useState([]);
     const [addFormOpen, setAddFormOpen] = useState(false);
@@ -218,7 +219,7 @@ export const User = () => {
                                             <TableCell className={classes.table_cell} style={{ width: '40%' }} component="th" scope="row">{this_user[0]}</TableCell>
                                             <TableCell className={classes.table_cell} style={{ width: '20%' }}>{this_user[2]}</TableCell>
                                             <TableCell className={classes.table_cell} style={{ width: '20%' }}>{this_user[1]}</TableCell>
-                                            <TableCell className={classes.table_cell} style={{ width: '20%' }} align="right"> {(this_user[0] === 'rods' || this_user[0] === 'public') ? <p></p> : <span><Link className={classes.link_button} to='/users/edit' state={{ userInfo: this_user }}><Button color="primary">Edit</Button></Link>
+                                            <TableCell className={classes.table_cell} style={{ width: '20%' }} align="right"> {(this_user[0] === loggedUserName || this_user[0] === 'public') ? <p></p> : <span><Link className={classes.link_button} to={`/users/edit?user=${encodeURIComponent(this_user[0]+'#'+this_user[2])}`}><Button color="primary">Edit</Button></Link>
                                                 <Button color="secondary" onClick={() => { handleRemoveConfirmationOpen(this_user) }}>Remove</Button></span>}</TableCell>
                                         </TableRow>
                                     ))}


### PR DESCRIPTION
This pr adds the following features to zmt:
- reworked the user interface (/user/edit, or clicking 'EDIT' on each row of users)
- implementation of user password management. ZMT currently prevents that from being empty, can discuss that
- icon button to toggle password visibility

![image](https://user-images.githubusercontent.com/33065086/149378126-3d26a7b3-0512-4e13-98ae-fc55a7459dfa.png)