### PR TITLE
Added checkfile for invalid resource name characters

### DIFF
--- a/src/data/checkfiles/default_checkfiles/validate-resc-chars.js
+++ b/src/data/checkfiles/default_checkfiles/validate-resc-chars.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Link } from '@reach/router'
+
+export default {
+    name: "Resources have valid names",
+    description: `Checks if the length of each resource is between 1 and 63 characters, starts and ends with a word character, and does not contain consecutive dashes.`,
+    minimum_server_version: "4.2.0",
+    maximum_server_version: "",
+    interval_in_seconds: 3600,
+    active: true,
+    checker: function () {
+        let result = {
+            status: '',
+            message: '',
+            success: 0,
+            failed: []
+        }
+
+        // regex taken from `irods/plugins/database/src/db_plugin.cpp`: https://github.com/irods/irods/blob/1c360003aea23c9bb80025c3c62dc7a0cef29524/plugins/database/src/db_plugin.cpp#LL684C23-L684C49
+
+        const regex = /^(?=.{1,63}$)\w+(-\w+)*$/; 
+
+        this.rescAll._embedded.forEach(resc => {
+            if (regex.test(resc[0])) {
+                result.success += 1
+            } else {
+                result.failed.push(resc[0])
+            }
+        })
+        result.status = result.failed.length > 0 ? 'warning' : 'healthy'
+        result.message = result.failed.length > 0 ? <span><span>Failed on: </span>{result.failed.map((failedResc,index) => <span key={`rescNameCheckFailed-${index}`}>{index !== 0 && ', '}<Link className="check_result_link" to={`/resources?filter=${encodeURIComponent(failedResc)}`}>{failedResc}</Link></span>)}</span> : 'All resource names have a valid name.'
+        return result
+    }
+}


### PR DESCRIPTION
Tested with an invalid resource name: `poo---f` and 3 valid resource names: `replResc`, `demoResc`, and `storageResc1`

<img width="1247" alt="Screenshot 2023-06-19 at 6 20 45 PM" src="https://github.com/irods/irods_client_zone_management_tool/assets/62436772/b127fc75-4401-402f-af5d-72f5302a2219">
