### PR TITLE
Added checkfiles for storage and coordinating resource children number

### DIFF
--- a/src/data/checkfiles/default_checkfiles/validate-coord-resc-children.js
+++ b/src/data/checkfiles/default_checkfiles/validate-coord-resc-children.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import { Link } from '@reach/router'
+
+export default {
+    name: "Coordinating resources have at least one child",
+    description: `Checks if all coordinating resources (deferred, random, passthru, load_balanced, replication, compound) have at least one child`,
+    minimum_server_version: "4.2.0",
+    maximum_server_version: "",
+    interval_in_seconds: 86400,
+    active: true,
+    checker: function () {
+        let result = {
+            status: '',
+            message: '',
+            success: 0,
+            failed: []
+        }
+
+        const coordResources = ['deferred', 'random', 'passthru', 'load_balanced', 'replication', 'compound'];
+        const parentResourceIds = new Set(); // resources with children
+        const coordResourceIds = [] // coordinating resource IDs
+
+        this.rescAll._embedded.forEach(resc => {
+            const name = resc[0];
+            const type = resc[1];
+            const zone = resc[2];
+            const parent = resc[10];
+            const id = resc[11];
+
+            if (parent) {
+                parentResourceIds.add(parent);
+            } else if (coordResources.includes(type)) {
+                coordResourceIds.push([id, name, type, zone]);
+            }
+        })
+
+        // if any ids in coordResourceIds are not in parentResourceIds (they have no children), add them to failed
+        coordResourceIds.forEach(coordResc => {
+            if (!parentResourceIds.has(coordResc[0])) {
+                result.failed.push(coordResc);
+            }
+        })
+
+        result.status = result.failed.length > 0 ? 'error' : 'healthy'
+        result.message = result.failed.length > 0 ? <span><span>Failed on: </span>{result.failed.map((failedResc,index) => <span key={`rescNameCheckFailed-${index}`}>{index !== 0 && ', '}<Link className="check_result_link" to={`/resources?filter=${encodeURIComponent(failedResc[1])}`}>{failedResc[1]}:{failedResc[3]} ({failedResc[2]})</Link></span>)}</span> : 'All coordinating resources have at least one child.';
+
+
+
+
+        return result
+    }
+}

--- a/src/data/checkfiles/default_checkfiles/validate-storage-resc-children.js
+++ b/src/data/checkfiles/default_checkfiles/validate-storage-resc-children.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { Link } from '@reach/router'
+
+export default {
+    name: "Storage resources have no children",
+    description: `Checks if all storage resources (unixfilesystem, univmss, s3) have no children`,
+    minimum_server_version: "4.2.0",
+    maximum_server_version: "",
+    interval_in_seconds: 86400,
+    active: true,
+    checker: function () {
+        let result = {
+            status: '',
+            message: '',
+            success: 0,
+            failed: []
+        }
+
+        const storageResources = ['unixfilesystem', 'univmss', 's3'];
+        const parentResourceIds = new Set(); // resources with children
+
+
+        this.rescAll._embedded.forEach(resc => {
+            const parent = resc[10];
+
+            if (parent) {
+                parentResourceIds.add(parent);
+            }
+        })
+
+        // loop through parentResourceIds and check if any are storage resources. if they are, add them to failed
+        parentResourceIds.forEach(id => {
+            const resc = this.rescAll._embedded.find(resc => resc[11] === id);
+            const name = resc[0];
+            const type = resc[1];
+            const zone = resc[2];
+
+            if (storageResources.includes(type)) {
+                result.failed.push([name, type, zone]);
+            }
+        })
+
+        result.status = result.failed.length > 0 ? 'error' : 'healthy'
+        result.message = result.failed.length > 0 ? <span><span>Failed on: </span>{result.failed.map((failedResc,index) => <span key={`rescNameCheckFailed-${index}`}>{index !== 0 && ', '}<Link className="check_result_link" to={`/resources?filter=${encodeURIComponent(failedResc[0])}`}>{failedResc[0]}:{failedResc[2]} ({failedResc[1]})</Link></span>)}</span> : 'All storage resources have no children.';
+
+        return result
+    }
+}


### PR DESCRIPTION

Coordinating resources (with children):
<img width="1487" alt="Screenshot 2023-06-21 at 1 27 48 PM" src="https://github.com/irods/irods_client_zone_management_tool/assets/62436772/f6bbf4aa-6565-4b12-821e-e2721e1abf96">

Coordinating resources (no children):
<img width="1496" alt="Screenshot 2023-06-21 at 1 26 29 PM" src="https://github.com/irods/irods_client_zone_management_tool/assets/62436772/e18edca9-1443-4e89-adc0-cb7b31ed92d6">

Storage resources (with children):
<img width="1502" alt="Screenshot 2023-06-21 at 1 30 18 PM" src="https://github.com/irods/irods_client_zone_management_tool/assets/62436772/2034ffc0-6ef4-464e-92e0-e979790282f4">

Storage resources (no children):
<img width="1485" alt="Screenshot 2023-06-21 at 1 34 04 PM" src="https://github.com/irods/irods_client_zone_management_tool/assets/62436772/1925f66e-e862-4189-b144-a56a2d98cd1f">


