### PR TITLE
Added encodeURIComponent() to SpecificQueryController.js

### DIFF
--- a/src/controllers/SpecificQueryController.js
+++ b/src/controllers/SpecificQueryController.js
@@ -11,7 +11,7 @@ export const AddSpecificQueryController = (alias, sqlStr, restApiLocation) => {
         params: {
             action: 'add',
             target: 'specificQuery',
-            arg2: sqlStr,
+            arg2: encodeURIComponent(sqlStr),
             arg3: alias 
         }
     })


### PR DESCRIPTION
Without `encodeURIComponent()`, adding a specific query sometimes will return `{"error_code":-130000,"error_message":"[json.exception.type_error.316] invalid UTF-8 byte at index 113: 0x7A"}`

EDIT: current fix has an issue with adding %20