### PR TITLE
Added support for remembering rows per page

### DIFF
--- a/src/contexts/EnvironmentContext.js
+++ b/src/contexts/EnvironmentContext.js
@@ -38,6 +38,12 @@ export const EnvironmentProvider = ({ children }) => {
             usersTitle: "Users",
             zonesTitle: "Zones",
 
+            groupsPerPageKey: "zmt-perpage-groups",
+            resourcesPageKey: "zmt-perpage-resources",
+            serversPageKey: "zmt-perpage-servers",
+            usersPageKey: "zmt-perpage-users",
+            defaultItemsPerPage: 25,
+
             pageTitle: "", // placeholder that gets filled on each page
             titleFormat: function () {
                 return `${this.pageTitle} - ${this.brandingName}`

--- a/src/contexts/ServerContext.js
+++ b/src/contexts/ServerContext.js
@@ -18,7 +18,7 @@ const queryGenerator = (_query, order, orderBy) => {
 }
 
 export const ServerProvider = ({ children }) => {
-    const { restApiLocation } = useEnvironment();
+    const environment = useEnvironment();
     const [zoneContext, setZoneContext] = useState([]);
     const [localZoneName, setLocalZoneName] = useState()
     const [zones, setZones] = useState()
@@ -54,7 +54,7 @@ export const ServerProvider = ({ children }) => {
 
             return axios({
                 method: 'GET',
-                url: `${restApiLocation}/query`,
+                url: `${environment.restApiLocation}/query`,
                 headers: {
                     'Authorization': localStorage.getItem('zmt-token')
                 },
@@ -88,7 +88,7 @@ export const ServerProvider = ({ children }) => {
 
             const resp1 = await axios({
                 method: 'GET',
-                url: `${restApiLocation}/query`,
+                url: `${environment.restApiLocation}/query`,
                 headers: {
                     'Authorization': localStorage.getItem('zmt-token')
                 },
@@ -103,7 +103,7 @@ export const ServerProvider = ({ children }) => {
 
             const resp2 = await axios({
                 method: 'GET',
-                url: `${restApiLocation}/query`,
+                url: `${environment.restApiLocation}/query`,
                 headers: {
                     'Authorization': localStorage.getItem('zmt-token')
                 },
@@ -118,7 +118,7 @@ export const ServerProvider = ({ children }) => {
             
             const resp3 = await axios({
                 method: 'GET',
-                url: `${restApiLocation}/query`,
+                url: `${environment.restApiLocation}/query`,
                 headers: {
                     'Authorization': localStorage.getItem('zmt-token')
                 },
@@ -179,7 +179,7 @@ export const ServerProvider = ({ children }) => {
     const loadGroupUserCounts = async (inputArray, offset, limit, order, orderBy) => {
         let groupUserCountPromises = inputArray._embedded.map(group => axios({
             method: 'GET',
-            url: `${restApiLocation}/query`,
+            url: `${environment.restApiLocation}/query`,
             headers: {
                 'Authorization': localStorage.getItem('zmt-token')
             },
@@ -217,7 +217,7 @@ export const ServerProvider = ({ children }) => {
         _query = queryGenerator(_query, order, orderBy);
         await axios({
             method: 'GET',
-            url: `${restApiLocation}/query`,
+            url: `${environment.restApiLocation}/query`,
             headers: {
                 'Authorization': localStorage.getItem('zmt-token')
             },
@@ -279,7 +279,7 @@ export const ServerProvider = ({ children }) => {
             let _query = queryGenerator(base_query, order, orderBy);
             return axios({
                 method: 'GET',
-                url: `${restApiLocation}/query`,
+                url: `${environment.restApiLocation}/query`,
                 headers: {
                     'Authorization': localStorage.getItem('zmt-token')
                 },
@@ -303,7 +303,7 @@ export const ServerProvider = ({ children }) => {
             let filteredResults = {};
             await axios({
                 method: 'GET',
-                url: `${restApiLocation}/query`,
+                url: `${environment.restApiLocation}/query`,
                 headers: {
                     'Authorization': localStorage.getItem('zmt-token')
                 },
@@ -322,7 +322,7 @@ export const ServerProvider = ({ children }) => {
             });
             await axios({
                 method: 'GET',
-                url: `${restApiLocation}/query`,
+                url: `${environment.restApiLocation}/query`,
                 headers: {
                     'Authorization': localStorage.getItem('zmt-token')
                 },
@@ -340,7 +340,7 @@ export const ServerProvider = ({ children }) => {
                 setIsLoadingRescContext(false);
             });
         }
-    }, [restApiLocation])
+    }, [environment.restApiLocation])
 
     const updatingRescPanelStatus = (text) => {
         setRescPanelStatus(text);
@@ -351,7 +351,7 @@ export const ServerProvider = ({ children }) => {
         let zonesRes = []
         const zoneData = await axios({
             method: 'GET',
-            url: `${restApiLocation}/query`,
+            url: `${environment.restApiLocation}/query`,
             headers: {
                 'Authorization': localStorage.getItem('zmt-token')
             },
@@ -375,7 +375,7 @@ export const ServerProvider = ({ children }) => {
         const zoneUserDataPromises = zoneData.data._embedded.map(zone => {
             return axios({
                 method: 'GET',
-                url: `${restApiLocation}/query`,
+                url: `${environment.restApiLocation}/query`,
                 headers: {
                     'Authorization': localStorage.getItem('zmt-token')
                 },
@@ -396,7 +396,7 @@ export const ServerProvider = ({ children }) => {
     const loadZoneReport = () => {
         return axios({
             method: 'GET',
-            url: `${restApiLocation}/zonereport`,
+            url: `${environment.restApiLocation}/zonereport`,
             headers: {
                 'Accept': 'application/json',
                 'Authorization': localStorage.getItem('zmt-token')
@@ -411,7 +411,7 @@ export const ServerProvider = ({ children }) => {
     const fetchServerResources = (server_hostname) => {
         return axios({
             method: 'GET',
-            url: `${restApiLocation}/query`,
+            url: `${environment.restApiLocation}/query`,
             headers: {
                 'Authorization': localStorage.getItem('zmt-token')
             },
@@ -427,7 +427,6 @@ export const ServerProvider = ({ children }) => {
     // load all servers at each render, and iterate through server list to fetch resources which have the same hostname
     const loadServers = async () => {
         setIsLoadingZoneContext(true);
-        const servers_limit = 10; // max number of servers to store, so we're not overwhelming the frontend
         let zone_report = await loadZoneReport();
 
         if (zone_report !== undefined) {
@@ -465,7 +464,10 @@ export const ServerProvider = ({ children }) => {
             }, []).sort(irodsVersionComparator))
             setRescTypes([...resc_types].sort())
             setZoneContext(fullServersArray)
-            setFilteredServers(fullServersArray.slice(0, servers_limit));
+            if (!localStorage.getItem(environment.serversPageKey)) {
+                localStorage.setItem(environment.serversPageKey, environment.defaultItemsPerPage);
+            }
+            setFilteredServers(fullServersArray.slice(0, parseInt(localStorage.getItem(environment.serversPageKey), 10)));
             setIsLoadingZoneContext(false);
         }
     }
@@ -505,7 +507,7 @@ export const ServerProvider = ({ children }) => {
         setIsLoadingSpecificQueryContext(true)
         axios({
             method: 'GET',
-            url: `${restApiLocation}/query`,
+            url: `${environment.restApiLocation}/query`,
             headers: {
                 'Authorization': localStorage.getItem('zmt-token')
             },
@@ -528,11 +530,25 @@ export const ServerProvider = ({ children }) => {
 
 
     const loadData = () => {
+        // not including servers key because we don't need to set default load amount here for it
+        const pageKeys = ["groupsPerPageKey", "resourcesPageKey", "usersPageKey"];
+
+        for (let key of pageKeys) {
+            if (!localStorage.getItem(environment[key])) {
+                localStorage.setItem(environment[key], environment.defaultItemsPerPage);
+            }
+        }
+
+        const groupsPerPage = parseInt(localStorage.getItem(environment[pageKeys[0]]), 10);
+        const rescPerPage = parseInt(localStorage.getItem(environment[pageKeys[1]]), 10);
+        const usersPerPage = parseInt(localStorage.getItem(environment[pageKeys[2]]), 10);
+        
+
         !isLoadingZones && loadZones();
         !isLoadingZoneContext && loadServers();
-        !isLoadingUserContext && loadUsers(0, 10, '', 'asc', 'USER_NAME');
-        !isLoadingGroupContext && loadGroups(0, 10, '', 'asc', 'USER_NAME');
-        !isLoadingRescContext && loadResources(0, 0, '', 'asc', 'RESC_NAME');
+        !isLoadingGroupContext && loadGroups(0, groupsPerPage, '', 'asc', 'USER_NAME');
+        !isLoadingRescContext && loadResources(0, rescPerPage, '', 'asc', 'RESC_NAME');
+        !isLoadingUserContext && loadUsers(0, usersPerPage, '', 'asc', 'USER_NAME');
         !isLoadingSpecificQueryContext && loadSpecificQueries('')
     }
 

--- a/src/views/Group.js
+++ b/src/views/Group.js
@@ -43,9 +43,11 @@ const useStyles = makeStyles((theme) => ({
 
 export const Group = () => {
     if (!localStorage.getItem('zmt-token')) navigate('/');
+
     const location = useLocation()
     const params = new URLSearchParams(location.search)
     const environment = useEnvironment();
+    const groupsPerPageKey = environment.groupsPerPageKey;
     const auth = localStorage.getItem('zmt-token');
     const classes = useStyles();
     const { isLoadingGroupContext, localZoneName, groupContext, loadGroups } = useServer();
@@ -56,10 +58,19 @@ export const Group = () => {
     const [currGroup, setCurrGroup] = useState([]);
     const [filterGroupName, setFilterName] = useState(params.get('filter') ? decodeURIComponent(params.get('filter')) : '');
     const [currPage, setCurrPage] = useState(1);
-    const [perPage, setPerPage] = useState(10);
+    const [perPage, setPerPage] = useState(parseInt(localStorage.getItem(groupsPerPageKey), 10));
     const [order, setOrder] = useState("asc");
     const [orderBy, setOrderBy] = useState("USER_NAME");
     let group_id = 0;
+
+    useEffect(() => {
+        // runs on initial render
+        const groupsPerPage = localStorage.getItem(groupsPerPageKey);
+        if (!groupsPerPage) {
+            localStorage.setItem(groupsPerPageKey, environment.defaultItemsPerPage);
+            setPerPage(environment.defaultItemsPerPage);
+        }
+    }, [])
 
     // load group from context provider,
     // pass in perPage, currentPage, filtername('' by default), order, orderBy
@@ -184,7 +195,7 @@ export const Group = () => {
                             Add New Group
                         </Button>
                     </div>
-                    <Fragment><TablePagination component="div" className={classes.pagination} page={currPage - 1} count={parseInt(groupContext.total)} rowsPerPage={perPage} onChangePage={handlePageChange} onChangeRowsPerPage={(e) => { setPerPage(e.target.value); setCurrPage(1) }} />
+                    <Fragment><TablePagination component="div" className={classes.pagination} page={currPage - 1} count={parseInt(groupContext.total)} rowsPerPage={perPage} onChangePage={handlePageChange} onChangeRowsPerPage={(e) => { setPerPage(e.target.value); setCurrPage(1); localStorage.setItem(groupsPerPageKey, e.target.value) }} />
                         <TableContainer className={classes.tableContainer} component={Paper}>
                             <Table aria-label="simple table">
                                 <TableHead>

--- a/src/views/Server.js
+++ b/src/views/Server.js
@@ -46,13 +46,24 @@ export const Server = () => {
     const classes = useStyles();
     const { isLoadingZoneContext, zoneContext, filteredServers, loadCurrServers } = useServer();
     const environment = useEnvironment();
+    const serversPageKey = environment.serversPageKey;
     const [currPage, setCurrPage] = useState(1);
-    const [perPage, setPerPage] = useState(10);
+    const [perPage, setPerPage] = useState(parseInt(localStorage.getItem(serversPageKey), 10));
     const [tabValue, setTabValue] = useState(0);
     const [openDetails, setOpenDetails] = useState(false);
     const [currServer, setCurrServer] = useState();
     const [order, setOrder] = useState("asc");
     const [orderBy, setOrderBy] = useState("role");
+
+    useEffect(() => {
+        // runs on initial render
+        const serversPerPage = localStorage.getItem(serversPageKey);
+        
+        if (!serversPerPage) {
+            localStorage.setItem(serversPageKey, environment.defaultItemsPerPage);
+            setPerPage(environment.defaultItemsPerPage);
+        } 
+    }, [])
 
     useEffect(() => {
         loadCurrServers(perPage * (currPage - 1), perPage, order, orderBy);
@@ -79,7 +90,7 @@ export const Server = () => {
             <br />
             {zoneContext === undefined ? <div>Cannot load server data. Please check your iRODS Client REST API endpoint connection.</div> :
                 <Fragment>
-                    <TablePagination component="div" className={classes.pagination} page={currPage - 1} count={parseInt(zoneContext.length)} rowsPerPage={perPage} onChangePage={(event, value) => { setCurrPage(value + 1) }} onChangeRowsPerPage={(e) => { setPerPage(e.target.value); setCurrPage(1) }} />
+                    <TablePagination component="div" className={classes.pagination} page={currPage - 1} count={parseInt(zoneContext.length)} rowsPerPage={perPage} onChangePage={(event, value) => { setCurrPage(value + 1) }} onChangeRowsPerPage={(e) => { setPerPage(e.target.value); setCurrPage(1); localStorage.setItem(serversPageKey, e.target.value) }} />
                     <TableContainer className={classes.tableContainer} component={Paper}>
                         <Table className={classes.table} aria-label="simple table">
                             <TableHead>

--- a/src/views/User.js
+++ b/src/views/User.js
@@ -48,9 +48,11 @@ const useStyles = makeStyles((theme) => ({
 
 export const User = () => {
     if (!localStorage.getItem('zmt-token')) navigate('/');
+
     const location = useLocation()
     const params = new URLSearchParams(location.search)
     const environment = useEnvironment();
+    const usersPageKey = environment.usersPageKey;
     const auth = localStorage.getItem('zmt-token');
     const loggedUserName = localStorage.getItem('zmt-username');
     const classes = useStyles();
@@ -61,7 +63,7 @@ export const User = () => {
     const userTypes = ["rodsuser", "rodsadmin", "groupadmin"];
     const [removeConfirmation, setRemoveConfirmation] = useState(false);
     const [currPage, setCurrPage] = useState(1);
-    const [perPage, setPerPage] = useState(10);
+    const [perPage, setPerPage] = useState(parseInt(localStorage.getItem(usersPageKey), 10));
     const [filterUsername, setFilterName] = useState(params.get('filter') ? decodeURIComponent(params.get('filter')) : "");
     const { isLoadingUserContext, userContext, localZoneName, loadUsers, zones } = useServer();
     const [order, setOrder] = useState("asc");
@@ -71,6 +73,15 @@ export const User = () => {
     const [isRunning, setIsRunning] = useState(false);
     const firstUpdate = useRef(true); // used to prevent filtering useEffect from running on initial render
     const delayTimeUse = environment.filterTimeInMilliseconds / 100; // convert into tenths of a second
+
+    useEffect(() => {
+        // runs on initial render
+        const usersPerPage = localStorage.getItem(usersPageKey);
+        if (!usersPerPage) {
+            localStorage.setItem(usersPageKey, environment.defaultItemsPerPage);
+            setPerPage(environment.defaultItemsPerPage);
+        }
+    }, [])
 
     useEffect(() => {
         // timer for keystroke delay
@@ -247,7 +258,7 @@ export const User = () => {
                             Add New User
                         </Button>
                     </div>
-                    <TablePagination component="div" className={classes.pagination} page={currPage - 1} count={parseInt(userContext.total)} rowsPerPage={perPage} onChangePage={handlePageChange} onChangeRowsPerPage={(e) => { setPerPage(e.target.value); setCurrPage(1) }} />
+                    <TablePagination component="div" className={classes.pagination} page={currPage - 1} count={parseInt(userContext.total)} rowsPerPage={perPage} onChangePage={handlePageChange} onChangeRowsPerPage={(e) => { setPerPage(e.target.value); setCurrPage(1); localStorage.setItem(usersPageKey, e.target.value) }} />
                     <TableContainer className={classes.tableContainer} component={Paper}>
                         <Table style={{ width: '100%', tableLayout: 'fixed' }} aria-label="User table">
                             <TableHead>

--- a/src/views/resources/ResourceListView.js
+++ b/src/views/resources/ResourceListView.js
@@ -44,6 +44,7 @@ const useStyles = makeStyles((theme) => ({
 
 export const ResourceListView = () => {
     if (!localStorage.getItem('zmt-token')) navigate('/');
+
     const location = useLocation()
     const params = new URLSearchParams(location.search)
     const auth = localStorage.getItem('zmt-token');
@@ -59,11 +60,21 @@ export const ResourceListView = () => {
     const [order, setOrder] = useState("asc");
     const [orderBy, setOrderBy] = useState("RESC_NAME");
     const [currPage, setCurrPage] = useState(1);
-    const [perPage, setPerPage] = useState(10);
-    const [filterRescName, setFilterName] = useState(params.get('filter') ? decodeURIComponent(params.get('filter')) : '');
     const environment = useEnvironment();
+    const resourcesPageKey = environment.resourcesPageKey;
+    const [perPage, setPerPage] = useState(parseInt(localStorage.getItem(resourcesPageKey), 10));
+    const [filterRescName, setFilterName] = useState(params.get('filter') ? decodeURIComponent(params.get('filter')) : '');
     const { isLoadingRescContext, localZoneName, validServerHosts, rescContext, rescTypes, loadResources, rescPanelStatus, updatingRescPanelStatus } = useServer();
 
+    useEffect(() => {
+        // runs on initial render
+        const resourcesPerPage = localStorage.getItem(resourcesPageKey);
+        if (!resourcesPerPage) {
+            localStorage.setItem(resourcesPageKey, environment.defaultItemsPerPage);
+            setPerPage(environment.defaultItemsPerPage);
+        }
+    }, [])
+    
     useEffect(() => {
         if (localZoneName) {
             loadResources((currPage - 1) * perPage, perPage, filterRescName, order, orderBy)
@@ -190,7 +201,7 @@ export const ResourceListView = () => {
                         Add New Resource
                     </Button>
                 </div>
-                <Fragment><TablePagination component="div" className={classes.pagination} page={currPage - 1} count={parseInt(rescContext.total)} rowsPerPage={perPage} onChangePage={handlePageChange} onChangeRowsPerPage={(e) => { setPerPage(e.target.value); setCurrPage(1) }} />
+                <Fragment><TablePagination component="div" className={classes.pagination} page={currPage - 1} count={parseInt(rescContext.total)} rowsPerPage={perPage} onChangePage={handlePageChange} onChangeRowsPerPage={(e) => { setPerPage(e.target.value); setCurrPage(1); localStorage.setItem(resourcesPageKey, e.target.value) }} />
                     <TableContainer className={classes.tableContainer} component={Paper}>
                         <Table style={{ width: '100%', tableLayout: 'fixed'}} aria-label="simple table">
                             <TableHead>


### PR DESCRIPTION
localStorage keys (from EnvironmentContext.js)
```
groupsPerPageKey: "zmt-perpage-groups",
resourcesPageKey: "zmt-perpage-resources",
serversPageKey: "zmt-perpage-servers",
usersPageKey: "zmt-perpage-users",
defaultAmount: 25,
```

happy to do a live demo of this. happy to discuss default amounts / naming